### PR TITLE
fix OutOfMemoryException when rebuilding from delta packages

### DIFF
--- a/src/Snap.Tests/Core/SnapPackTests.cs
+++ b/src/Snap.Tests/Core/SnapPackTests.cs
@@ -1163,18 +1163,17 @@ namespace Snap.Tests.Core
             update3SnapReleaseBuilder.AssertChecksums(update3PackageContext.FullPackageSnapApp, update3PackageContext.DeltaPackageSnapRelease,
                 update3ExtractedFiles);
                     
-            var (fullNupkgMemoryStream, fullSnapApp, fullSnapRelease) = await _snapPack.RebuildPackageAsync(
+            var (fullSnapApp, fullSnapRelease) = await _snapPack.RebuildPackageAsync(
                 update3SnapReleaseBuilder.SnapAppPackagesDirectory,
                 snapAppsReleases.GetReleases(update3PackageContext.DeltaPackageSnapApp,
                     update3PackageContext.DeltaPackageSnapApp.GetCurrentChannelOrThrow()),
-                update3PackageContext.DeltaPackageSnapRelease);
+                update3PackageContext.DeltaPackageSnapRelease,filesystem:_snapFilesystem);
 
-            await using (fullNupkgMemoryStream)
-            {
-                Assert.NotNull(fullNupkgMemoryStream);
-                Assert.Equal(update3PackageContext.FullPackageSnapApp.BuildNugetFilename(), fullSnapApp.BuildNugetFilename());
-                Assert.Equal(update3PackageContext.FullPackageSnapRelease.BuildNugetFilename(), fullSnapRelease.BuildNugetFilename());
-            }
+            var packageFile = _snapFilesystem.PathCombine(update3SnapReleaseBuilder.SnapAppPackagesDirectory, fullSnapRelease.Filename);
+            Assert.True(_snapFilesystem.FileDeleteIfExists(packageFile));
+
+            Assert.Equal(update3PackageContext.FullPackageSnapApp.BuildNugetFilename(), fullSnapApp.BuildNugetFilename());
+            Assert.Equal(update3PackageContext.FullPackageSnapRelease.BuildNugetFilename(), fullSnapRelease.BuildNugetFilename());
         }
 
         [Fact]

--- a/src/Snap/Core/SnapPack.cs
+++ b/src/Snap/Core/SnapPack.cs
@@ -584,12 +584,13 @@ namespace Snap.Core
             if (packagesDirectory == null) throw new ArgumentNullException(nameof(packagesDirectory));
             if (snapAppChannelReleases == null) throw new ArgumentNullException(nameof(snapAppChannelReleases));
             if (snapRelease == null) throw new ArgumentNullException(nameof(snapRelease));
+            if (filesystem == null) throw new ArgumentNullException(nameof(filesystem));
 
             
 
             var (packageBuilder, fullSnapApp, fullSnapRelease) =
                 await RebuildFullPackageAsyncInternal(packagesDirectory, snapAppChannelReleases, snapRelease, rebuildPackageProgressSource, cancellationToken);
-            using var filestream=filesystem.FileWrite(filesystem.PathCombine(packagesDirectory, fullSnapRelease.Filename));
+            await using var filestream=filesystem.FileWrite(filesystem.PathCombine(packagesDirectory, fullSnapRelease.Filename));
             packageBuilder.Save(filestream);
 
             snapRelease.Sort();

--- a/src/Snap/Core/SnapPackageManager.cs
+++ b/src/Snap/Core/SnapPackageManager.cs
@@ -541,19 +541,13 @@ namespace Snap.Core
                 {
                     try
                     {
-                        var (fullNupkgMemoryStream, _, fullSnapRelease) =
-                            await _snapPack.RebuildPackageAsync(packagesDirectory, snapAppChannelReleases, x, compoundProgressSource, cancellationToken);
+                        var ( _, fullSnapRelease) =
+                            await _snapPack.RebuildPackageAsync(packagesDirectory, snapAppChannelReleases, x, compoundProgressSource, _filesystem, cancellationToken);
 
-                        await using (fullNupkgMemoryStream)
-                        {
-                            var fullNupkgAbsolutePath = _filesystem.PathCombine(packagesDirectory, fullSnapRelease.Filename);
-                            await _filesystem.FileWriteAsync(fullNupkgMemoryStream, fullNupkgAbsolutePath, cancellationToken);
+                        var releasesReassembledSoFarVolatile = Interlocked.Increment(ref releasesReassembled);
+                        restoreSummary.ReassembleSummary.Add(new SnapPackageManagerReleaseStatus(fullSnapRelease, true));
 
-                            var releasesReassembledSoFarVolatile = Interlocked.Increment(ref releasesReassembled);
-                            restoreSummary.ReassembleSummary.Add(new SnapPackageManagerReleaseStatus(fullSnapRelease, true));
-
-                            logger?.Debug($"Successfully restored {releasesReassembledSoFarVolatile} of {releasesToReassemble.Count()}.");
-                        }
+                        logger?.Debug($"Successfully restored {releasesReassembledSoFarVolatile} of {releasesToReassemble.Count()}.");
                     }
                     catch (Exception e)
                     {


### PR DESCRIPTION
## What does the pull request do?
With large projects rebuilding a package from the delta packages was throwing an `OutOfMemoryException`.

## What is the current behavior?
Rebuilding the packages was saving first into a `MemoryStream` and afterwards into the `FileStream`. 

## What is the updated/expected behavior with this PR?
Rebuilding directly saves the package to the `FileStream`

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?