### PR TITLE
add option to skip waiting for the updated nuget feed at the end of pack/promote/demote

### DIFF
--- a/src/Snapx/Options/DemoteOptions.cs
+++ b/src/Snapx/Options/DemoteOptions.cs
@@ -33,6 +33,10 @@ namespace snapx.Options
             HelpText = "Override lock token.")]
         public string LockToken { get; set; }
 
+        [Option("skip-await-update", 
+            HelpText = "Skip waiting for the nuget feed update.")]
+        public bool SkipAwaitUpdate { get; set; }
+
         [Value(0,
             HelpText = "The Application id.",
             Required = true)]

--- a/src/Snapx/Options/PackOptions.cs
+++ b/src/Snapx/Options/PackOptions.cs
@@ -48,6 +48,10 @@ namespace snapx.Options
             HelpText = "Skip building installers.")]
         public bool SkipInstallers { get; set; }
 
+        [Option("skip-await-update", 
+            HelpText = "Skip waiting for the nuget feed update.")]
+        public bool SkipAwaitUpdate { get; set; }
+
         [Option("release-notes", 
             HelpText = "Overwrite release notes defined in YML manifest.")]
         public string ReleasesNotes { get; set; }

--- a/src/Snapx/Options/PromoteOptions.cs
+++ b/src/Snapx/Options/PromoteOptions.cs
@@ -41,6 +41,11 @@ namespace snapx.Options
         [Option("skip-installers",
             HelpText = "Skip building installers.")]
         public bool SkipInstallers { get; set; }
+        
+        [Option("skip-await-update", 
+            HelpText = "Skip waiting for the nuget feed update.")]
+        public bool SkipAwaitUpdate { get; set; }
+
 
         [Value(0, HelpText = "Application id", Required = true)]
         public string Id { get; [UsedImplicitly] set; }

--- a/src/Snapx/Program.CommandDemote.cs
+++ b/src/Snapx/Program.CommandDemote.cs
@@ -264,7 +264,7 @@ namespace snapx
             var skipInitialBlock = packageSource.IsLocalOrUncPath();
 
             await BlockUntilSnapUpdatedReleasesNupkgAsync(logger, snapPackageManager, snapAppsReleases, anyRidSnapApp, 
-                anySnapTargetDefaultChannel, TimeSpan.FromSeconds(15), cancellationToken, skipInitialBlock);
+                anySnapTargetDefaultChannel, TimeSpan.FromSeconds(15), cancellationToken, skipInitialBlock, options.SkipAwaitUpdate);
 
             logger.Info('-'.Repeat(TerminalBufferWidth));
 

--- a/src/Snapx/Program.CommandPack.cs
+++ b/src/Snapx/Program.CommandPack.cs
@@ -418,7 +418,7 @@ namespace snapx
             var skipInitialBlock = pushFeedPackageSource.IsLocalOrUncPath();
 
             await BlockUntilSnapUpdatedReleasesNupkgAsync(logger, snapPackageManager, snapAppsReleases,
-                snapApp, snapChannel, TimeSpan.FromSeconds(15), cancellationToken, skipInitialBlock);
+                snapApp, snapChannel, TimeSpan.FromSeconds(15), cancellationToken, skipInitialBlock,packOptions.SkipAwaitUpdate );
         }
     }
 }

--- a/src/Snapx/Program.CommandPromote.cs
+++ b/src/Snapx/Program.CommandPromote.cs
@@ -299,7 +299,7 @@ namespace snapx
                 var skipInitialBlock = packageSource.IsLocalOrUncPath();
 
                 await BlockUntilSnapUpdatedReleasesNupkgAsync(logger, snapPackageManager,
-                    snapAppsReleases, snapApp, channel, TimeSpan.FromSeconds(15), cancellationToken, skipInitialBlock);
+                    snapAppsReleases, snapApp, channel, TimeSpan.FromSeconds(15), cancellationToken, skipInitialBlock,options.SkipAwaitUpdate );
 
                 logger.Info($"Successfully uploaded releases nupkg to channel: {channel.Name}.");
                 logger.Info('-'.Repeat(TerminalBufferWidth));

--- a/src/Snapx/Program.cs
+++ b/src/Snapx/Program.cs
@@ -568,8 +568,9 @@ namespace snapx
 
         static async Task BlockUntilSnapUpdatedReleasesNupkgAsync([NotNull] ILog logger, [NotNull] ISnapPackageManager snapPackageManager,
             [NotNull] SnapAppsReleases snapAppsReleases, [NotNull] SnapApp snapApp,
-            [NotNull] SnapChannel snapChannel, TimeSpan retryInterval, CancellationToken cancellationToken, bool skipInitialBlock = true)
+            [NotNull] SnapChannel snapChannel, TimeSpan retryInterval, CancellationToken cancellationToken, bool skipInitialBlock = true, bool skipAwaitUpdate=false)
         {
+            if (skipAwaitUpdate) return;
             if (logger == null) throw new ArgumentNullException(nameof(logger));
             if (snapPackageManager == null) throw new ArgumentNullException(nameof(snapPackageManager));
             if (snapAppsReleases == null) throw new ArgumentNullException(nameof(snapAppsReleases));


### PR DESCRIPTION
this is helpful in scenarios where the nuget feed isn't directly updated by snapx
for example with sleet (https://github.com/emgarten/Sleet)

## What does the pull request do?
add the option to skip waiting for the updated nuget feed at the end


## What is the current behavior?
waiting for the updated nuget feed in pack, promote, demote


## What is the updated/expected behavior with this PR?
adds the command line option to skip the waiting

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?